### PR TITLE
Fixed bug where errors were not propagated correctly.

### DIFF
--- a/include.js
+++ b/include.js
@@ -82,8 +82,8 @@ function include(inputdir, outputdir, options) {
 								file: outputFilename,
 								source: inputFilename,
 								hires: true
-							})
-						)
+							}).toString()
+						);
 					});
 
 				} else {

--- a/include.js
+++ b/include.js
@@ -76,15 +76,15 @@ function include(inputdir, outputdir, options) {
 					}
 
 					// Write files (source + map)
-					return sander.writeFile( outputFilename, magicString.toString() + sourceMapping).then(
-						sander.writeFile( outputFilename + '.map',
+					return sander.writeFile( outputFilename, magicString.toString() + sourceMapping).then(function() {
+						return sander.writeFile( outputFilename + '.map',
 							magicString.generateMap({
 								file: outputFilename,
 								source: inputFilename,
 								hires: true
 							})
 						)
-					);
+					});
 
 				} else {
 					code = code.replace( pattern, function ( match, $1 ) {


### PR DESCRIPTION
A promise was passed to `then`, instead of a function which returns a promise. This caused errors to not bubble up correctly and fail the build, instead just logging a possibly unhandled rejection.
